### PR TITLE
Has Been Added Event Handling for Coin List with Error Management

### DIFF
--- a/app/src/main/java/com/halilkrkn/capcoin/MainActivity.kt
+++ b/app/src/main/java/com/halilkrkn/capcoin/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.halilkrkn.capcoin
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -11,8 +12,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.halilkrkn.capcoin.core.presentation.util.ObserveAsEvents
+import com.halilkrkn.capcoin.core.presentation.util.toString
+import com.halilkrkn.capcoin.presentation.coin_list.CoinListEvent
 import com.halilkrkn.capcoin.presentation.coin_list.CoinListScreen
 import com.halilkrkn.capcoin.presentation.coin_list.CoinListState
 import com.halilkrkn.capcoin.presentation.coin_list.CoinListViewModel
@@ -28,6 +33,18 @@ class MainActivity : ComponentActivity() {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     val viewModel = koinViewModel<CoinListViewModel>()
                     val state by viewModel.state.collectAsStateWithLifecycle()
+                    val context = LocalContext.current
+                    ObserveAsEvents(events = viewModel.events) { event ->
+                        when (event) {
+                            is CoinListEvent.Error -> {
+                                Toast.makeText(
+                                    context,
+                                    event.error.toString(context),
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
+                        }
+                    }
 
                     CoinListScreen(
                         state = state,

--- a/app/src/main/java/com/halilkrkn/capcoin/core/presentation/util/NetworkErrorToString.kt
+++ b/app/src/main/java/com/halilkrkn/capcoin/core/presentation/util/NetworkErrorToString.kt
@@ -1,0 +1,18 @@
+package com.halilkrkn.capcoin.core.presentation.util
+
+import android.content.Context
+import com.halilkrkn.capcoin.R
+import com.halilkrkn.capcoin.core.util.NetworkError
+
+fun NetworkError.toString(context: Context): String {
+    val resId = when (this) {
+        NetworkError.REQUEST_TIMEOUT -> R.string.error_request_timeout
+        NetworkError.TOO_MANY_REQUESTS -> R.string.error_too_many_requests
+        NetworkError.NO_INTERNET_CONNECTION -> R.string.error_no_internet_connection
+        NetworkError.SERVER_ERROR -> R.string.error_server_error
+        NetworkError.SERIALIZATION_ERROR -> R.string.error_serialization
+        NetworkError.UNKNOWN_ERROR -> R.string.error_unknown
+    }
+
+    return context.getString(resId)
+}

--- a/app/src/main/java/com/halilkrkn/capcoin/core/presentation/util/ObserveAsEvents.kt
+++ b/app/src/main/java/com/halilkrkn/capcoin/core/presentation/util/ObserveAsEvents.kt
@@ -1,0 +1,30 @@
+package com.halilkrkn.capcoin.core.presentation.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+
+@Composable
+fun <T> ObserveAsEvents(
+    events: Flow<T>,
+    key1: Any? = null,
+    key2: Any? = null,
+    onEvent: (T) -> Unit,
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    // Bu yapı, MVVM mimarisinde ViewModel'den gelen hata eventlerini kullanıcıya göstermek için kullanılan REACTIVE bir PATTERN'dir
+    LaunchedEffect(key1 = lifecycleOwner.lifecycle, key1, key2) {
+        // Komponentin STARTED durumunda olduğunda çalışır
+        // Komponent arka plana geçtiğinde otomatik olarak durur ve öne geldiğinde devam eder(tekar çalışır).
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            withContext(Dispatchers.Main.immediate) {
+                events.collect(onEvent)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/halilkrkn/capcoin/presentation/coin_list/CoinListEvent.kt
+++ b/app/src/main/java/com/halilkrkn/capcoin/presentation/coin_list/CoinListEvent.kt
@@ -1,0 +1,7 @@
+package com.halilkrkn.capcoin.presentation.coin_list
+
+import com.halilkrkn.capcoin.core.util.NetworkError
+
+sealed interface CoinListEvent {
+    data class Error(val error: NetworkError) : CoinListEvent
+}

--- a/app/src/main/java/com/halilkrkn/capcoin/presentation/coin_list/CoinListScreen.kt
+++ b/app/src/main/java/com/halilkrkn/capcoin/presentation/coin_list/CoinListScreen.kt
@@ -1,5 +1,6 @@
 package com.halilkrkn.capcoin.presentation.coin_list
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -11,22 +12,57 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import com.halilkrkn.capcoin.domain.models.Coin
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import com.halilkrkn.capcoin.core.presentation.util.toString
 import com.halilkrkn.capcoin.presentation.coin_list.components.CoinListItem
 import com.halilkrkn.capcoin.presentation.coin_list.components.previewCoin
-import com.halilkrkn.capcoin.presentation.models.CoinUI
 import com.halilkrkn.capcoin.ui.theme.CapCoinTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.withContext
 
 @Composable
 fun CoinListScreen(
     state: CoinListState,
-    modifier: Modifier = Modifier
+//    events: Flow<CoinListEvent>,
+    modifier: Modifier = Modifier,
 ) {
+
+
+
+
+/*    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    // Bu yapı, MVVM mimarisinde ViewModel'den gelen hata eventlerini kullanıcıya göstermek için kullanılan REACTIVE bir PATTERN'dir
+    LaunchedEffect(key1 = lifecycleOwner.lifecycle) {
+        // Komponentin STARTED durumunda olduğunda çalışır
+        // Komponent arka plana geçtiğinde otomatik olarak durur ve öne geldiğinde devam eder(tekar çalışır).
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            withContext(Dispatchers.Main.immediate) {
+                events.collect { event ->
+                    when (event) {
+                        is CoinListEvent.Error -> {
+                            Toast.makeText(
+                                context,
+                                event.error.toString(context),
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    }
+                }
+            }
+        }
+    }*/
+
     if (state.isLoading) {
         Box(
             modifier = modifier
@@ -41,7 +77,7 @@ fun CoinListScreen(
             modifier = modifier
                 .fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(8.dp)
-        ){
+        ) {
             items(state.coins) { coinUi ->
                 CoinListItem(
                     coinUI = coinUi,
@@ -56,6 +92,7 @@ fun CoinListScreen(
     }
 }
 
+
 @PreviewLightDark
 @Composable
 private fun CoinListScreenPreview() {
@@ -66,6 +103,7 @@ private fun CoinListScreenPreview() {
                     previewCoin.copy(id = it.toString())
                 }
             ),
+//            events = emptyFlow(),
             modifier = Modifier.background(MaterialTheme.colorScheme.background)
         )
     }

--- a/app/src/main/java/com/halilkrkn/capcoin/presentation/coin_list/CoinListViewModel.kt
+++ b/app/src/main/java/com/halilkrkn/capcoin/presentation/coin_list/CoinListViewModel.kt
@@ -6,10 +6,11 @@ import com.halilkrkn.capcoin.core.util.onError
 import com.halilkrkn.capcoin.core.util.onSuccess
 import com.halilkrkn.capcoin.domain.CoinDataSource
 import com.halilkrkn.capcoin.presentation.models.toCoinUi
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -27,6 +28,19 @@ class CoinListViewModel(
             CoinListState()
         )
 
+    /* Events - Channel
+    // event (olay) yönetimi için kullanılan bir yapı
+    // Bu yapı genellikle ViewModel'den UI'ya one-time eventler (bir kere tetiklenecek olaylar) göndermek için kullanılır.
+    // Örneğin:
+        - Navigation eventleri
+        - Snackbar mesajları
+        - Dialog gösterme komutları
+        - Bir defaya mahsus bildirimler
+    // `StateFlow`'dan farklı olarak `Channel`, her eventi sadece bir kere iletir ve tüketildikten sonra kaybolur.
+    */
+    private val _events = Channel<CoinListEvent>()
+    val events = _events.receiveAsFlow()
+
     fun onAction(action: CoinListAction) {
         when (action) {
             is CoinListAction.OnCoinClick -> {
@@ -42,18 +56,19 @@ class CoinListViewModel(
                 it.copy(isLoading = true)
             }
 
-            coinDataSource.getCoins().onSuccess { coins ->
-                _state.update {
-                    it.copy(
-                        isLoading = false, coins = coins.map { coin ->
-                            coin.toCoinUi()
-                        })
+            coinDataSource
+                .getCoins()
+                .onSuccess { coins ->
+                    _state.update {
+                        it.copy(
+                            isLoading = false, coins = coins.map { coin ->
+                                coin.toCoinUi()
+                            })
+                    }
+                }.onError { error ->
+                    _state.update { it.copy(isLoading = false) }
+                    _events.send(CoinListEvent.Error(error))
                 }
-            }.onError {
-                _state.update {
-                    it.copy(isLoading = false)
-                }
-            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,10 +1,11 @@
 <resources>
-    <string name="app_name">CryptoTracker</string>
+    <string name="app_name">CapCoin</string>
     <string name="error_request_timeout">The request timed out.</string>
     <string name="error_too_many_requests">Oops, it seems like your quota is exceeded.</string>
-    <string name="error_no_internet">Couldn\'t connect to server, please check your internet connection.</string>
+    <string name="error_no_internet_connection">Couldn\'t connect to server, please check your internet connection.</string>
     <string name="error_unknown">Something went wrong. Please try again later.</string>
     <string name="error_serialization">Couldn\'t serialize or deserialize data.</string>
+    <string name="error_server_error">Something went wrong. Please try again later.</string>
     <string name="market_cap">Market Cap</string>
     <string name="price">Price</string>
     <string name="change_last_24h">Change last 24h</string>


### PR DESCRIPTION
feat: Added Error Handling and Event Management in CoinList

- Implemented `NetworkError.toString()` to display network errors as user-friendly messages.
- Introduced `CoinListEvent` and `ObserveAsEvents` to manage and display one-time events like errors.
- Modified `CoinListViewModel` to emit error events using `Channel` when `getCoins()` fails.
- Integrated error event handling in `MainActivity` to show `Toast` messages for errors.
- Updated `CoinListScreen` to handle the new error event structure.
- Changed app name from "CryptoTracker" to "CapCoin".
